### PR TITLE
Porting for SPRESENSE board

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -47,7 +47,7 @@ int EthernetClient::connect(IPAddress ip, uint16_t port)
 		}
 		sockindex = MAX_SOCK_NUM;
 	}
-#if defined(ESP8266) || defined(ESP32)
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SPRESENSE)
 	if (ip == IPAddress((uint32_t)0) || ip == IPAddress(0xFFFFFFFFul)) return 0;
 #else
 	if (ip == IPAddress(0ul) || ip == IPAddress(0xFFFFFFFFul)) return 0;

--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -48,6 +48,11 @@
 #define SPI_ETHERNET_SETTINGS SPISettings(8000000, MSBFIRST, SPI_MODE0)
 #endif
 
+// Spresense's SPI can uses SPI_MODE3 with auto cs control by hardware.
+#if defined(ARDUINO_ARCH_SPRESENSE)
+#undef SPI_ETHERNET_SETTINGS
+#define SPI_ETHERNET_SETTINGS SPISettings(14000000, MSBFIRST, SPI_MODE3)
+#endif
 
 typedef uint8_t SOCKET;
 
@@ -432,6 +437,21 @@ private:
 	inline static void resetSS() {
 		*(ss_pin_reg+6) = ss_pin_mask;
 	}
+
+#elif defined(ARDUINO_ARCH_SPRESENSE)
+	inline static void initSS() {
+		if (ss_pin != 10)
+			pinMode(ss_pin, OUTPUT);
+	}
+	inline static void setSS() {
+		if (ss_pin != 10)
+			digitalWrite(ss_pin, LOW);
+	}
+	inline static void resetSS() {
+		if (ss_pin != 10)
+			digitalWrite(ss_pin, HIGH);
+	}
+
 #else
 	inline static void initSS() {
 		pinMode(ss_pin, OUTPUT);


### PR DESCRIPTION
Spresense's SPI has hardware automatic ss control that is not programmable by
software. So the transfer data must be buffered and transferred all at once.